### PR TITLE
GP-2333: Add checking 'if address is real' when update address.

### DIFF
--- a/CRM/Streetimport/GP/Handler/TEDIContactRecordHandler.php
+++ b/CRM/Streetimport/GP/Handler/TEDIContactRecordHandler.php
@@ -800,13 +800,17 @@ class CRM_Streetimport_GP_Handler_TEDIContactRecordHandler extends CRM_Streetimp
       }
     }
 
-    $isRealAddress = CRM_Streetimport_GP_Utils_Address::isRealAddress(
-      $address_data['city'],
-      $address_data['postal_code'],
-      $address_data['street_address']
-    );
+    $isCurrentCountryAustria = !empty($record['Land']) && trim($record['Land']) == CRM_Streetimport_GP_Utils_Address::AUSTRIA_ISO_CODE;
+    $isRealAustriaAddress = FALSE;
+    if ($isCurrentCountryAustria && !empty($record['strasse']) && !empty($record['PLZ']) && !empty($record['Ort'])) {
+      $isRealAustriaAddress = CRM_Streetimport_GP_Utils_Address::isRealAddress(
+        trim($record['Ort']),
+        trim($record['PLZ']),
+        trim($record['strasse'])
+      );
+    }
 
-    if ($full_overwrite && $isRealAddress) {
+    if ($full_overwrite && (!$isCurrentCountryAustria || ($isCurrentCountryAustria && $isRealAustriaAddress))) {
       // this is a proper address update
       $address_data['id'] = $old_address_id;
       $this->setProvince($address_data);

--- a/CRM/Streetimport/GP/Utils/Address.php
+++ b/CRM/Streetimport/GP/Utils/Address.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Class provide Address helper methods
+ */
+class CRM_Streetimport_GP_Utils_Address {
+
+  /**
+   * Checks if address is real by 'de.systopia.postcodeat' extension functionality
+   * If 'de.systopia.postcodeat' extension does not install that method returns false
+   *
+   * @param $city
+   * @param $postalCode
+   * @param $street
+   *
+   * @return bool
+   */
+  public static function isRealAddress($city, $postalCode, $street) {
+    if (empty($city) || empty($postalCode) || empty($street)) {
+      return FALSE;
+    }
+
+    try {
+      $address = civicrm_api3('PostcodeAT', 'get', [
+        'sequential' => 1,
+        'plznr' => $postalCode,
+        'ortnam' => $city,
+        'stroffi' => $street,
+        'return' => 'id',
+      ]);
+
+      $ortnamSearchResult = !empty($address['values']);
+    } catch (CiviCRM_API3_Exception $e) {
+      $ortnamSearchResult = FALSE;
+    }
+
+    try {
+      $address = civicrm_api3('PostcodeAT', 'get', [
+        'sequential' => 1,
+        'plznr' => $postalCode,
+        'gemnam38' => $city,
+        'stroffi' => $street,
+        'return' => 'id',
+      ]);
+
+      $gemnam38SearchResult = !empty($address['values']);
+    } catch (CiviCRM_API3_Exception $e) {
+      $gemnam38SearchResult = FALSE;
+    }
+
+    return $gemnam38SearchResult || $ortnamSearchResult;
+  }
+
+}

--- a/CRM/Streetimport/GP/Utils/Address.php
+++ b/CRM/Streetimport/GP/Utils/Address.php
@@ -6,6 +6,13 @@
 class CRM_Streetimport_GP_Utils_Address {
 
   /**
+   * Austria iso code
+   *
+   * @var string
+   */
+  const AUSTRIA_ISO_CODE = 'AT';
+
+  /**
    * Checks if address is real by 'de.systopia.postcodeat' extension functionality
    * If 'de.systopia.postcodeat' extension does not install that method returns false
    *
@@ -27,6 +34,7 @@ class CRM_Streetimport_GP_Utils_Address {
         'ortnam' => $city,
         'stroffi' => $street,
         'return' => 'id',
+        'strict_fields_searching' => ["stroffi", 'ortnam', 'plznr'],
       ]);
 
       $ortnamSearchResult = !empty($address['values']);
@@ -41,6 +49,7 @@ class CRM_Streetimport_GP_Utils_Address {
         'gemnam38' => $city,
         'stroffi' => $street,
         'return' => 'id',
+        'strict_fields_searching' => ["stroffi", 'gemnam38', 'plznr'],
       ]);
 
       $gemnam38SearchResult = !empty($address['values']);


### PR DESCRIPTION
1. Fix methods description.
2. When If country is not Austria, it does not check if 'is real address'.
3. If country is Austria, it checks if 'is real address' by `zip('plznr')`+`street('stroffi')` + `city('ortnam' or 'gemnam38')` params in `PostcodeAT->get` API.
3. Change workflow 'updating address' method. Workflow for now:
![GP-2333_v2](https://user-images.githubusercontent.com/36959503/60195827-877fab80-9844-11e9-8c47-df257e3408cc.png)


About settings and workflow:
- Current domain: `GP' => 'Greenpeace Austria`.
- Example csv file name: `GP_UmwP_tedi_C0001_20190603_034625_mehrfach_Interessenten_DA_436467_Kontakte.csv`.
- For that csv file runs handler - `CRM_Streetimport_GP_Handler_TEDIContactRecordHandler`.
- It can be tested in `Streetimport->importcsvfile`API.