### PR TITLE
GP-2497: Parse 'JahresBetrag' and 'BuchungsBetrag' field by German format number

### DIFF
--- a/CRM/Streetimport/GP/Handler/GPRecordHandler.php
+++ b/CRM/Streetimport/GP/Handler/GPRecordHandler.php
@@ -246,7 +246,7 @@ abstract class CRM_Streetimport_GP_Handler_GPRecordHandler extends CRM_Streetimp
     }
 
     // FIRST: compile and create SEPA mandate
-    $annual_amount = $record['JahresBetrag'];
+    $annual_amount = CRM_Streetimport_GP_Utils_Number::parseGermanFormatNumber($record['JahresBetrag']);
     $frequency = $record['Einzugsintervall'];
     $amount = number_format($annual_amount / $frequency, 2);
     $mandate_params = array(
@@ -316,7 +316,7 @@ abstract class CRM_Streetimport_GP_Handler_GPRecordHandler extends CRM_Streetimp
       'type'                => 'OOFF',
       'iban'                => $record['IBAN'],
       'bic'                 => $bic,
-      'amount'              => number_format($record['BuchungsBetrag'], 2),
+      'amount'              => number_format(CRM_Streetimport_GP_Utils_Number::parseGermanFormatNumber($record['BuchungsBetrag']), 2),
       'contact_id'          => $contact_id,
       'currency'            => 'EUR',
       'receive_date'        => $mandate_start_date,
@@ -373,7 +373,7 @@ abstract class CRM_Streetimport_GP_Handler_GPRecordHandler extends CRM_Streetimp
     }
 
     // send upgrade notification
-    $annual_amount = $record['JahresBetrag'];
+    $annual_amount = CRM_Streetimport_GP_Utils_Number::parseGermanFormatNumber($record['JahresBetrag']);
     $frequency = $record['Einzugsintervall'];
     $contract_modification = array(
       'action'                                  => $action,

--- a/CRM/Streetimport/GP/Utils/Number.php
+++ b/CRM/Streetimport/GP/Utils/Number.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * Class provide Number helper methods
+ */
+class CRM_Streetimport_GP_Utils_Number {
+
+  /**
+   * Parses German number format
+   * Example:
+   *  1.234,56(string) => 1234.56(float)
+   *  234,56(string) => 234.56(float)
+   *  234(string) => 234(float)
+   *  1.000(string) => 1000(float)
+   *
+   * If is not German number format it returns not parsed number
+   *
+   * @param $stringNumber
+   *
+   * @return float
+   */
+  public static function parseGermanFormatNumber($stringNumber) {
+    if (empty($stringNumber)) {
+      return $stringNumber;
+    }
+
+    $stringNumber = str_replace(' ', '', $stringNumber);
+
+    if (!CRM_Streetimport_GP_Utils_Number::isGermanFormatNumber($stringNumber)) {
+      return $stringNumber;
+    }
+
+    $cleanStringNumber = str_replace('.', '', $stringNumber);
+    $cleanStringNumber = str_replace(',', '.', $cleanStringNumber);
+
+    return floatval($cleanStringNumber);
+  }
+
+  /**
+   * Check if that German number format
+   *
+   * @param $stringNumber
+   *
+   * @return bool
+   */
+  public static function isGermanFormatNumber($stringNumber) {
+    $pattern ='/^-?\d{1,3}(?:\.\d{3})*(?:,\d+)?$/';
+
+    return (bool) (preg_match($pattern, $stringNumber));
+  }
+
+}


### PR DESCRIPTION
About parse functionality:
It convert German number(string) into float format.
If is not German number format it returns not parsed number.
(That checks by regular expression.)
Example:
- 1.234,56(string) => 1234.56(float)
- 234,56(string) => 234.56(float)
- 234(string) => 234(float)
- 1.000(string) => 1000(float)


