### PR TITLE
Add PostAT return handler

### DIFF
--- a/CRM/Streetimport/GP/Config.php
+++ b/CRM/Streetimport/GP/Config.php
@@ -59,7 +59,8 @@ class CRM_Streetimport_GP_Config extends CRM_Streetimport_Config {
       new CRM_Streetimport_GP_Handler_TEDITelephoneRecordHandler($logger),
       new CRM_Streetimport_GP_Handler_TEDIContactRecordHandler($logger),
       new CRM_Streetimport_GP_Handler_DDRecordHandler($logger),
-      new CRM_Streetimport_GP_Handler_PostRetourRecordHandler($logger),
+      new CRM_Streetimport_GP_Handler_PostalReturn_LegacyRecordHandler($logger),
+      new CRM_Streetimport_GP_Handler_PostalReturn_PostATRecordHandler($logger),
       new CRM_Streetimport_GP_Handler_StyriaRecordHandler($logger),
       new CRM_Streetimport_GP_Handler_PostAddressCheckHandler($logger),
     );

--- a/CRM/Streetimport/GP/Handler/PostalReturn/LegacyRecordHandler.php
+++ b/CRM/Streetimport/GP/Handler/PostalReturn/LegacyRecordHandler.php
@@ -1,0 +1,101 @@
+<?php
+/*-------------------------------------------------------------+
+| GP StreetImporter Record Handlers                            |
+| Copyright (C) 2017 SYSTOPIA                                  |
+| Author: B. Endres (endres -at- systopia.de)                  |
+| http://www.systopia.de/                                      |
++--------------------------------------------------------------*/
+
+/**
+ * Processes legacy postal return barcode lists (GP-331)
+ *
+ * @author Björn Endres (SYSTOPIA) <endres@systopia.de>
+ * @license AGPL-3.0
+ */
+class CRM_Streetimport_GP_Handler_PostalReturn_LegacyRecordHandler extends CRM_Streetimport_GP_Handler_PostalReturn_Base {
+
+  /** file name / reference patterns as defined in GP-331 */
+  protected static $FILENAME_PATTERN       = '#^RTS_(?P<category>[a-zA-Z\-]+)(_[0-9]*)?[.][a-zA-Z]+$#';
+
+  /** stores the parsed file name */
+  protected $file_name_data = 'not parsed';
+
+  /**
+   * Check if the given handler implementation can process the record
+   *
+   * @param $record  an array of key=>value pairs
+   * @param $sourceURI
+   *
+   * @return true or false
+   */
+  public function canProcessRecord($record, $sourceURI) {
+    if ($this->file_name_data === 'not parsed') {
+      $this->file_name_data = $this->parseRetourFile($sourceURI);
+    }
+    return $this->file_name_data != NULL;
+  }
+
+  /**
+   * Process the given record
+   *
+   * @param $record  an array of key=>value pairs
+   * @param $sourceURI
+   *
+   * @return true
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function processRecord($record, $sourceURI) {
+    $reference = $this->getReference($record);
+    if (empty($reference)) {
+      return $this->logger->logImport($record, FALSE, 'RTS', "Empty reference '{$reference}'");
+    }
+    if (empty($this->getCampaignID($record))) {
+      return $this->logger->logImport($record, FALSE, 'RTS', "Couldn't identify campaign for reference '{$reference}'");
+    }
+    if (empty($this->getContactID($record))) {
+      return $this->logger->logImport($record, FALSE, 'RTS', "Couldn't identify contact for reference '{$reference}'");
+    }
+
+    $this->processReturn($record);
+
+    $this->logger->logImport($record, TRUE, 'RTS');
+  }
+
+  /**
+   * Get category
+   *
+   * @param $record
+   *
+   * @return mixed
+   */
+  protected function getCategory($record) {
+    return $this->file_name_data['category'];
+  }
+
+  /**
+   * Will try to parse the given name and extract the parameters outlined in TM_PATTERN
+   *
+   * @param $sourceID
+   *
+   * @return NULL if not matched, data else
+   */
+  protected function parseRetourFile($sourceID) {
+    if (preg_match(self::$FILENAME_PATTERN, basename($sourceID), $matches)) {
+      return $matches;
+    } else {
+      return NULL;
+    }
+  }
+
+  /**
+   * Get the reference
+   *
+   * @param $record
+   *
+   * @return mixed
+   */
+  protected function getReference($record) {
+    return trim(CRM_Utils_Array::value('scanned_code', $record));
+  }
+
+}

--- a/CRM/Streetimport/GP/Handler/PostalReturn/PostATRecordHandler.php
+++ b/CRM/Streetimport/GP/Handler/PostalReturn/PostATRecordHandler.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * Processes postal returns from post.at's managed return service
+ *
+ * @author Patrick Figel <pfigel@greenpeace.org>
+ * @license AGPL-3.0
+ */
+class CRM_Streetimport_GP_Handler_PostalReturn_PostATRecordHandler extends CRM_Streetimport_GP_Handler_PostalReturn_Base {
+
+  /**
+   * File name in the format RET_KUNDE_MAILING_JJJJMMTT.csv
+   *
+   * @var string
+   */
+  protected static $FILENAME_PATTERN = '#^RET_(?P<org>[a-zA-Z\-]+)_(?P<mailing>[a-zA-Z0-9\-]+)_(?P<date>\d{8})?[.]csv$#';
+
+  /** stores the parsed file name */
+  protected $file_name_data = 'not parsed';
+
+  /**
+   * Check if the given handler implementation can process the record
+   *
+   * @param $record  an array of key=>value pairs
+   * @param $sourceURI
+   *
+   * @return true or false
+   */
+  public function canProcessRecord($record, $sourceURI) {
+    if ($this->file_name_data === 'not parsed') {
+      $this->file_name_data = $this->parseRetourFile($sourceURI);
+    }
+    return $this->file_name_data != NULL;
+  }
+
+  /**
+   * Process the given record
+   *
+   * @param $record  an array of key=>value pairs
+   * @param $sourceURI
+   *
+   * @return true
+   * @throws \CiviCRM_API3_Exception
+   */
+  public function processRecord($record, $sourceURI) {
+    $reference = $this->getReference($record);
+    if (empty($reference)) {
+      $this->logger->logError("Empty RTS reference", $record);
+    }
+    if (empty($this->getCategory($record))) {
+      $this->logger->logError("Unknown postal return category '{$record['Grund']}'", $record);
+      return $this->logger->logImport($record, FALSE, 'RTS', "Couldn't identify RTS category");
+    }
+    if (empty($this->getCampaignID($record))) {
+      $this->logger->logError("Invalid RTS campaign_id in reference '{$reference}'", $record);
+      return $this->logger->logImport($record, FALSE, 'RTS', "Couldn't identify campaign for reference '{$reference}'");
+    }
+    if (empty($this->getContactID($record))) {
+      // create an import error unless this is a deleted contact
+      if (!$this->isDeletedContact($this->getContactID($record, TRUE))) {
+        $this->logger->logError("Invalid RTS contact_id in reference '{$reference}'", $record);
+      }
+      return $this->logger->logImport($record, FALSE, 'RTS', "Couldn't identify contact for reference '{$reference}'");
+    }
+
+    $this->processReturn($record);
+
+    $this->logger->logImport($record, TRUE, 'RTS');
+  }
+
+  /**
+   * Get category
+   *
+   * @param $record
+   *
+   * @return mixed
+   */
+  protected function getCategory($record) {
+    $codeCategoryMap = [
+      '01' => 'unknown',
+      '02' => 'rejected',
+      '03' => 'moved',
+      '04' => 'notretrieved',
+      '05' => 'incomplete',
+      '06' => 'deceased',
+      '07' => 'other',
+      '08' => 'badcode',
+      '09' => 'unused',
+    ];
+    if (!array_key_exists($record['Grund'], $codeCategoryMap)) {
+      return NULL;
+    }
+    return $codeCategoryMap[$record['Grund']];
+  }
+
+  /**
+   * Will try to parse the given name and extract the parameters outlined in TM_PATTERN
+   *
+   * @param $sourceID
+   *
+   * @return NULL if not matched, data else
+   */
+  protected function parseRetourFile($sourceID) {
+    if (preg_match(self::$FILENAME_PATTERN, basename($sourceID), $matches)) {
+      return $matches;
+    } else {
+      return NULL;
+    }
+  }
+
+  /**
+   * Get the reference
+   *
+   * @param $record
+   *
+   * @return mixed
+   */
+  protected function getReference($record) {
+    return trim(CRM_Utils_Array::value('Adnr', $record));
+  }
+
+  /**
+   * @param $record
+   *
+   * @return string
+   */
+  public function getDate($record) {
+    return $record['EinspDatum'] . '000000' ?? parent::getDate($record);
+  }
+
+}


### PR DESCRIPTION
This adds a new PostAT postal return handler. This handler is fairly similar to the existing `PostRetourRecordHandler`, so this includes a refactoring to extract much of the code into a new base class that is used by both postal return handlers.

Some of the existing business logic was changed: We now use the activity date of postal mailings to determine whether an address has been changed, unless the mailing cannot be found.