### PR TITLE
GP-26059 Improve PL Authorization compatibility with CE

### DIFF
--- a/CRM/Streetimport/GPPL/Handler/BankAuthorizationHandler.php
+++ b/CRM/Streetimport/GPPL/Handler/BankAuthorizationHandler.php
@@ -53,6 +53,7 @@ class CRM_Streetimport_GPPL_Handler_BankAuthorizationHandler extends CRM_Streeti
       'membership_id' => $record['membership_id'],
     ]);
     if ($membership['count'] == 0) {
+      $this->logger->logError($config->translate('Membership not found'), $record);
       $this->logger->logImport($record, FALSE, $config->translate('Bank Authorization'), $config->translate('Membership not found'));
       return;
     }
@@ -80,6 +81,7 @@ class CRM_Streetimport_GPPL_Handler_BankAuthorizationHandler extends CRM_Streeti
           $this->logger->logImport($record, TRUE, $config->translate('Bank Authorization'), $config->translate('Ignoring, Membership is already active'));
         }
         else {
+          $this->logger->logError($config->translate('Membership is in an undefined state (' . $membership['status_id'] . ')'), $record);
           $this->logger->logImport($record, FALSE, $config->translate('Bank Authorization'), $config->translate('Membership is in an undefined state'));
         }
       }
@@ -102,11 +104,13 @@ class CRM_Streetimport_GPPL_Handler_BankAuthorizationHandler extends CRM_Streeti
           $this->logger->logImport($record, TRUE, $config->translate('Bank Authorization'), $config->translate('Cancelled Membership'));
         }
         else {
+          $this->logger->logError($config->translate('Membership is in an undefined state (' . $membership['status_id'] . ')'), $record);
           $this->logger->logImport($record, FALSE, $config->translate('Bank Authorization'), $config->translate('Membership is in an undefined state (' . $membership['status_id'] . ')'));
         }
       }
     }
     catch (CRM_Streetimport_GPPL_Handler_BankAuthorizationHandlerException $e) {
+      $this->logger->logError('Error: ' . $e->getMessage(), $record);
       $this->logger->logImport($record, FALSE, $config->translate('Bank Authorization'), 'Error: ' . $e->getMessage());
       return;
     }


### PR DESCRIPTION
This fixes a number of issues in PL's Bank Authorization Handler:
- Use implicit dates when using CE's API to avoid use of dates in the past or blocked by `contract_minimum_change_date`
- Explicitly set `source_contact_id` for all activities created by the handler
- Use configurable fundraiser contact ID as source contact
- Remove unnecessary `activity_date_time` filter when looking for pending resume activities
- Use `CRM_Contract_Utils::getDefaultContractChangeDate()` when determining next upcoming cycle day and when updating resume date