### PR TITLE
GP-47846 Fix contract activity parent update

### DIFF
--- a/CRM/Streetimport/GP/Handler/TEDIContactRecordHandler.php
+++ b/CRM/Streetimport/GP/Handler/TEDIContactRecordHandler.php
@@ -187,9 +187,7 @@ class CRM_Streetimport_GP_Handler_TEDIContactRecordHandler extends CRM_Streetimp
             return $this->logger->abort("Format violation, the record type requires a contract_id.", $record);
           } else {
             $contract_id = $this->createContract($contact_id, $record);
-            if (!empty($parent_id)) {
-              $this->setContractActivityParent($contract_id, $parent_id);
-            }
+            $this->setContractActivityParent($contract_id, $parent_id);
           }
         } else {
           // load the contract
@@ -215,9 +213,6 @@ class CRM_Streetimport_GP_Handler_TEDIContactRecordHandler extends CRM_Streetimp
 
               // ALL GOOD: do the upgrade!
               $this->updateContract($contract_id, $contact_id, $record, $membership_type_id, $modify_command);
-              if (!empty($parent_id)) {
-                $this->setContractActivityParent($contract_id, $parent_id);
-              }
             }
           }
         }
@@ -236,9 +231,6 @@ class CRM_Streetimport_GP_Handler_TEDIContactRecordHandler extends CRM_Streetimp
         $membership = $this->getContract($record, $contact_id);
         if ($membership) {
           $this->cancelContract($membership, $record);
-          if (!empty($parent_id)) {
-            $this->setContractActivityParent($membership['id'], $parent_id);
-          }
         } else {
           $this->logger->logWarning("NO contract (membership) found.", $record);
         }
@@ -247,21 +239,11 @@ class CRM_Streetimport_GP_Handler_TEDIContactRecordHandler extends CRM_Streetimp
       case TM_KONTAKT_RESPONSE_KONTAKT_LOESCHEN:
         // contact wants to be erased from GP database
         $result = $this->disableContact($contact_id, 'erase', $record);
-        if (!empty($parent_id)) {
-          foreach ($result['cancelled_contracts'] as $membership_id) {
-            $this->setContractActivityParent($membership_id, $parent_id);
-          }
-        }
         break;
 
       case TM_KONTAKT_RESPONSE_KONTAKT_STILLEGEN:
         // contact should be disabled
         $result = $this->disableContact($contact_id, 'disable', $record);
-        if (!empty($parent_id)) {
-          foreach ($result['cancelled_contracts'] as $membership_id) {
-            $this->setContractActivityParent($membership_id, $parent_id);
-          }
-        }
         break;
 
       case TM_KONTAKT_RESPONSE_NICHT_KONTAKTIEREN:
@@ -271,11 +253,6 @@ class CRM_Streetimport_GP_Handler_TEDIContactRecordHandler extends CRM_Streetimp
       case TM_KONTAKT_RESPONSE_KONTAKT_VERSTORBEN:
         // contact should be disabled
         $result = $this->disableContact($contact_id, 'deceased', $record);
-        if (!empty($parent_id)) {
-          foreach ($result['cancelled_contracts'] as $membership_id) {
-            $this->setContractActivityParent($membership_id, $parent_id);
-          }
-        }
         break;
 
       case TM_KONTAKT_RESPONSE_KONTAKT_ANRUFSPERRE:

--- a/CRM/Streetimport/GP/Handler/TMResponseRecordHandler.php
+++ b/CRM/Streetimport/GP/Handler/TMResponseRecordHandler.php
@@ -126,9 +126,6 @@ class CRM_Streetimport_GP_Handler_TMResponseRecordHandler extends CRM_Streetimpo
       case TM_KONTAKT_RESPONSE_KONTAKT_LOESCHEN:
         // contact wants to be erased from GP database
         $result = $this->disableContact($contact_id, 'erase', $record);
-        foreach ($result['cancelled_contracts'] as $membership_id) {
-          $this->setContractActivityParent($membership_id, $parent_id);
-        }
         break;
 
       case TM_KONTAKT_RESPONSE_NICHT_KONTAKTIEREN:
@@ -145,9 +142,6 @@ class CRM_Streetimport_GP_Handler_TMResponseRecordHandler extends CRM_Streetimpo
       case TM_KONTAKT_RESPONSE_KONTAKT_VERSTORBEN:
         // contact should be disabled
         $result = $this->disableContact($contact_id, 'deceased', $record);
-        foreach ($result['cancelled_contracts'] as $membership_id) {
-          $this->setContractActivityParent($membership_id, $parent_id);
-        }
         break;
 
       case TM_KONTAKT_RESPONSE_KONTAKT_KEIN_ANSCHLUSS:


### PR DESCRIPTION
This fixes an issue where parent activities of contract activities are sometimes set to a TM activity even if the contract activity was not triggered by the import/TM activity at all.

Previously, the import attempted to find related contract activities by simply looking up the latest contract activity for a membership. This produces false positives e.g. if a membership has already been cancelled through other means, causing that previous cancellation to be linked to the TM activity.

This changes the import so that we set the parent field only for the exact activity returned by a CE API call triggered by the import, except in the case of new memberships (where there cannot be any existing unrelated contract activities).