### PR TITLE
EN-37 Fix case activity link being created twice

### DIFF
--- a/CRM/Streetimport/Utils.php
+++ b/CRM/Streetimport/Utils.php
@@ -818,14 +818,6 @@ class CRM_Streetimport_Utils {
       civicrm_api3('Activity', 'create', $custom_data);
     }
 
-    // we wouldn't need to do this if this whole thing just used Activity.create ...
-    if (!empty($data['case_id'])) {
-      $caseActivity = new CRM_Case_DAO_CaseActivity();
-      $caseActivity->case_id = $data['case_id'];
-      $caseActivity->activity_id = $activity->id;
-      $caseActivity->save();
-    }
-
     return $activity;
   }
 


### PR DESCRIPTION
This fixes an issue where mulitple CaseActivity records are created for activities linked to cases. This is due to core starting to accept case_id in its BAO code at some point.